### PR TITLE
Very small bug fix

### DIFF
--- a/source/StoryTeller/Execution/ProjectRunner.cs
+++ b/source/StoryTeller/Execution/ProjectRunner.cs
@@ -102,6 +102,9 @@ namespace StoryTeller.Execution
             catch (Exception e)
             {
                 Console.WriteLine(e);
+            }
+            finally
+            {
                 runner.Dispose();
             }
         }


### PR DESCRIPTION
The ISystem TeardownEnvironment method was not being called from the command line runner but it was being called from the UI.

I moved the dispose to the finally and ran the rake script and all the tests passed.

-Ryan
