### PR TITLE
Added Retry knowledge for TeamCityListener

### DIFF
--- a/src/StoryTeller.TestRunner/TestRunner.cs
+++ b/src/StoryTeller.TestRunner/TestRunner.cs
@@ -87,5 +87,10 @@ namespace StoryTeller.TestRunner
         {
             return true;
         }
+
+        public void FinishTestRetries(Test test)
+        {
+            
+        }
     }
 }

--- a/src/StoryTeller.Testing/Engine/TestContextTester.cs
+++ b/src/StoryTeller.Testing/Engine/TestContextTester.cs
@@ -569,6 +569,11 @@ namespace StoryTeller.Testing.Engine
             return StepsRun < StepsAllowed;
         }
 
+        public void FinishTestRetries(Test test)
+        {
+            
+        }
+
         #endregion
     }
 

--- a/src/StoryTeller/Engine/ConsoleListener.cs
+++ b/src/StoryTeller/Engine/ConsoleListener.cs
@@ -64,6 +64,11 @@ namespace StoryTeller.Engine
             return true;
         }
 
+        public virtual void FinishTestRetries(Test test)
+        {
+            write("Final test status after retries: {0}", test.LastResult.Counts.WasSuccessful() ? "Successful" : "Failure");
+        }
+
         public override object InitializeLifetimeService()
         {
             return null;

--- a/src/StoryTeller/Engine/ITestObserver.cs
+++ b/src/StoryTeller/Engine/ITestObserver.cs
@@ -15,5 +15,6 @@ namespace StoryTeller.Engine
         void Exception(string exceptionString);
 
         bool CanContinue(Counts counts);
+        void FinishTestRetries(Test test);
     }
 }

--- a/src/StoryTeller/Engine/TeamCityTestListener.cs
+++ b/src/StoryTeller/Engine/TeamCityTestListener.cs
@@ -21,6 +21,24 @@ namespace StoryTeller.Engine
             {
                 if (test.Lifecycle == Lifecycle.Regression)
                 {
+                    Console.WriteLine("##teamcity[testIgnored name='{0}' details='{1}']", test.Name.Escape(),
+                                      getFailureDetails(test).Escape());
+                }
+                else
+                {
+                    Console.WriteLine("##teamcity[testIgnored name='{0}' message='{1}']", test.Name.Escape(),
+                                      "Acceptance test failed: " + getFailureDetails(test).Escape());
+                }
+            }
+            Console.WriteLine("##teamcity[testFinished name='{0}']", test.Name.Escape());
+        }
+
+        public override void FinishTestRetries(Test test)
+        {
+            if (!test.LastResult.Counts.WasSuccessful())
+            {
+                if (test.Lifecycle == Lifecycle.Regression)
+                {
                     Console.WriteLine("##teamcity[testFailed name='{0}' details='{1}']", test.Name.Escape(),
                                       getFailureDetails(test).Escape());
                 }

--- a/src/StoryTeller/Execution/ITestRunnerDomain.cs
+++ b/src/StoryTeller/Execution/ITestRunnerDomain.cs
@@ -1,4 +1,5 @@
 using System;
+using StoryTeller.Domain;
 using StoryTeller.Engine;
 using StoryTeller.Model;
 using StoryTeller.Workspace;
@@ -15,6 +16,7 @@ namespace StoryTeller.Execution
         TestResult RunTest(TestExecutionRequest request);
         void AbortCurrentTest();
         bool IsExecuting();
+        void MarkTestFinalStatus(Test test);
 
         FixtureLibrary Library { get; }
         void UseTeamCityListener();

--- a/src/StoryTeller/Execution/InProcessTestEngine.cs
+++ b/src/StoryTeller/Execution/InProcessTestEngine.cs
@@ -1,4 +1,5 @@
 using System;
+using StoryTeller.Domain;
 using StoryTeller.Engine;
 using StoryTeller.Model;
 using StoryTeller.Workspace;
@@ -43,6 +44,11 @@ namespace StoryTeller.Execution
         }
 
         public bool IsExecuting()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void MarkTestFinalStatus(Test test)
         {
             throw new NotImplementedException();
         }

--- a/src/StoryTeller/Execution/ProjectTestRunner.cs
+++ b/src/StoryTeller/Execution/ProjectTestRunner.cs
@@ -149,7 +149,8 @@ namespace StoryTeller.Execution
                     }
                     _engine.RunTest(t);
                     numberOfRetries++;
-                }                
+                }
+                _engine.TestRetriesFinished(t);
                 callback(t);
             });
         }

--- a/src/StoryTeller/Execution/TestEngine.cs
+++ b/src/StoryTeller/Execution/TestEngine.cs
@@ -119,7 +119,6 @@ namespace StoryTeller.Execution
         public void AbortCurrentTest()
         {
             _domain.AbortCurrentTest();
-
             
         }
 
@@ -163,6 +162,11 @@ namespace StoryTeller.Execution
         public void UseTeamCityListener()
         {
             _domain.UseTeamCityListener();
+        }
+
+        public void TestRetriesFinished(Test test)
+        {
+            _domain.MarkTestFinalStatus(test);
         }
     }
 }

--- a/src/StoryTeller/Execution/UserInterfaceTestObserver.cs
+++ b/src/StoryTeller/Execution/UserInterfaceTestObserver.cs
@@ -119,5 +119,11 @@ namespace StoryTeller.Execution
         {
             _publisher.Publish(GetStatus());
         }
+
+
+        public void FinishTestRetries(Test test)
+        {
+            
+        }
     }
 }


### PR DESCRIPTION
We were getting a lot of false test fails on TeamCity since the listener wasn't aware of the retry concept.  Basically the test would run, fail, and TC would be notified of a failed test.  The retry would run, pass, and TC would be notified the test finished.  TeamCity would display a failed run since it was told a test failed even though the test passed on the retry.  Chad and I paired and came up with these changes to make the listener aware.  So basically what happens the test runs, if it passes then it calls the MarkTestFinalStatus method which runs the code FinishTest used to perform for the listener.  The listener was modified to ignore failed tests on FinishTest and to mark them as passed/failed on the MarkTestFinalStatus method which is called on the last run test.  This will alleviate the false test fails on TeamCity.  I'm not sure if this is right solution so I wanted to push a pull request for Jeremy to check out and either pull in or let me know a better way to handle this.
