### PR TITLE
Bandaid for teamcity reporting

### DIFF
--- a/src/StoryTeller/Engine/TeamCityTestListener.cs
+++ b/src/StoryTeller/Engine/TeamCityTestListener.cs
@@ -12,7 +12,7 @@ namespace StoryTeller.Engine
 
         public override void StartTest(Test test, Counts counts)
         {
-            Console.WriteLine("##teamcity[testStarted name='{0}']", test.Name.Escape());
+          Console.WriteLine("##teamcity[testStarted name='{0}']", test.Name.Escape());
         }
 
         public override void FinishTest(Test test)
@@ -23,7 +23,7 @@ namespace StoryTeller.Engine
 
         public override void FinishTestRetries(Test test)
         {
-            if (!test.LastResult.Counts.WasSuccessful())
+            if (test.LastResult != null && !test.LastResult.Counts.WasSuccessful())
             {
                 if (test.Lifecycle == Lifecycle.Regression)
                 {

--- a/src/StoryTeller/Execution/ProjectTestRunner.cs
+++ b/src/StoryTeller/Execution/ProjectTestRunner.cs
@@ -4,6 +4,7 @@ using FubuCore;
 using StoryTeller.Assertions;
 using StoryTeller.Domain;
 using StoryTeller.Engine;
+using StoryTeller.Engine.TeamCity;
 using StoryTeller.Model;
 using StoryTeller.Workspace;
 using System.Linq;
@@ -145,7 +146,11 @@ namespace StoryTeller.Execution
                 {
                     if (numberOfRetries != 0)
                     {
-                        Console.WriteLine("$$$$$$$$$$$$$$$$Previous pass failed -- retrying: {0}".ToFormat(t.GetStatus()));
+                      // Fixes reporting Hiearchy on test retry fails
+                      Console.WriteLine("##teamcity[message text='{0}']", 
+                                        "$$$$$$$$$$$$$$$$Previous pass failed -- retrying: {0}".ToFormat(t.GetStatus()));
+                      Console.WriteLine("##teamcity[testFinished name='{0}' duration='{1}']", t.Name.Escape(), t.LastResult.ExecutionTime);
+                      t.Reset();
                     }
                     _engine.RunTest(t);
                     numberOfRetries++;

--- a/src/StoryTeller/Execution/TestRunnerDomain.cs
+++ b/src/StoryTeller/Execution/TestRunnerDomain.cs
@@ -124,8 +124,10 @@ namespace StoryTeller.Execution
 
         public void MarkTestFinalStatus(Test test)
         {
-            if (_listener != null)
-                _listener.FinishTestRetries(test);
+          if (_listener == null)
+            _listener = new TeamCityTestListener();
+
+          _listener.FinishTestRetries(test);
         }
 
         public FixtureLibrary Library


### PR DESCRIPTION
Storyteller TeamCityTestListener wasn't being set on the TestRunnerDomain when UseTeamCityReporter is used, added a check if _listener is null to default to TeamCityTestListener, also modifed retry teamcity reporting to use the message type and not use the ignore.  TeamCity docs say ignore should only be used once per test, prior to this request we used it for all retries.
