### PR TITLE
Retry attempt count pass through

### DIFF
--- a/src/StoryTeller.Testing/Engine/AutoPerformingTestContext.cs
+++ b/src/StoryTeller.Testing/Engine/AutoPerformingTestContext.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using FubuCore;
 using FubuCore.Conversion;
 using FubuCore.Formatting;
 using FubuCore.Util;
@@ -14,6 +13,11 @@ namespace StoryTeller.Testing.Engine
         #region ITestContext Members
 
         public IEnumerable<Type> StartupActionTypes
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public int AttemptNumber
         {
             get { throw new NotImplementedException(); }
         }

--- a/src/StoryTeller/Domain/Test.cs
+++ b/src/StoryTeller/Domain/Test.cs
@@ -47,7 +47,7 @@ namespace StoryTeller.Domain
         public string SuiteName { get; set; }
         public Suite Parent { get; private set; }
         public int NumberOfRetries { get; set; }
-        public int AtemptNumber { get; set; }
+        public int AttemptNumber { get; set; }
         public void SetParent(Suite parent)
         {
             Parent = parent;

--- a/src/StoryTeller/Domain/Test.cs
+++ b/src/StoryTeller/Domain/Test.cs
@@ -47,6 +47,7 @@ namespace StoryTeller.Domain
         public string SuiteName { get; set; }
         public Suite Parent { get; private set; }
         public int NumberOfRetries { get; set; }
+        public int AtemptNumber { get; set; }
         public void SetParent(Suite parent)
         {
             Parent = parent;

--- a/src/StoryTeller/Engine/TestContext.cs
+++ b/src/StoryTeller/Engine/TestContext.cs
@@ -36,6 +36,7 @@ namespace StoryTeller.Engine
     public interface ITestContext
     {
         IEnumerable<Type> StartupActionTypes { get; }
+        int AttemptNumber { get; }
 
         object CurrentObject { get; set; }
         IObjectConverter Finder { get; }
@@ -358,6 +359,8 @@ namespace StoryTeller.Engine
         {
             get { return StartupActionNames.Select(x => GetStartupType(x)); }
         }
+
+        public int AttemptNumber { get { return Test.AtemptNumber; } }
 
         public object CurrentObject { get; set; }
 

--- a/src/StoryTeller/Engine/TestContext.cs
+++ b/src/StoryTeller/Engine/TestContext.cs
@@ -360,7 +360,7 @@ namespace StoryTeller.Engine
             get { return StartupActionNames.Select(x => GetStartupType(x)); }
         }
 
-        public int AttemptNumber { get { return Test.AtemptNumber; } }
+        public int AttemptNumber { get { return Test.AttemptNumber; } }
 
         public object CurrentObject { get; set; }
 

--- a/src/StoryTeller/Execution/ProjectTestRunner.cs
+++ b/src/StoryTeller/Execution/ProjectTestRunner.cs
@@ -147,7 +147,7 @@ namespace StoryTeller.Execution
                     {
                         Console.WriteLine("$$$$$$$$$$$$$$$$Previous pass failed -- retrying: {0}".ToFormat(t.GetStatus()));
                     }
-                    t.AtemptNumber = numberOfRetries;
+                    t.AttemptNumber = numberOfRetries;
                     _engine.RunTest(t);
                     numberOfRetries++;
                 }

--- a/src/StoryTeller/Execution/ProjectTestRunner.cs
+++ b/src/StoryTeller/Execution/ProjectTestRunner.cs
@@ -147,6 +147,7 @@ namespace StoryTeller.Execution
                     {
                         Console.WriteLine("$$$$$$$$$$$$$$$$Previous pass failed -- retrying: {0}".ToFormat(t.GetStatus()));
                     }
+                    t.AtemptNumber = numberOfRetries;
                     _engine.RunTest(t);
                     numberOfRetries++;
                 }

--- a/src/StoryTeller/Persistence/TestReader.cs
+++ b/src/StoryTeller/Persistence/TestReader.cs
@@ -67,6 +67,7 @@ namespace StoryTeller.Persistence
             
             var test = new Test(name, suiteName, parts);
             readLifecycle(test, element);
+            readAttemptNumber(test, element);
             return test;
         }
 
@@ -95,6 +96,16 @@ namespace StoryTeller.Persistence
             var lifecycle = (Lifecycle) Enum.Parse(typeof (Lifecycle), lifecycleString, true);
 
             test.Lifecycle = lifecycle;
+        }
+
+        private static void readAttemptNumber(Test test, INode element)
+        {
+            string attemptNumberString = element["attemptnumber"];
+            if (attemptNumberString.IsEmpty()) return;
+
+            var attemptNumber = int.Parse(attemptNumberString);
+
+            test.AttemptNumber = attemptNumber;
         }
 
         public ITestPart ReadPart(INode node)

--- a/src/StoryTeller/Persistence/WriterVisitor.cs
+++ b/src/StoryTeller/Persistence/WriterVisitor.cs
@@ -82,6 +82,7 @@ namespace StoryTeller.Persistence
         {
             _root["name"] = _test.Name;
             _root["lifecycle"] = _test.Lifecycle.ToString();
+            _root["attemptnumber"] = _test.AttemptNumber.ToString();
 
             _nodes.Push(_root);
 


### PR DESCRIPTION
So we ran into a situation where web driver is occasionally screwed up so bad that we just need to shut it down and restart it. However, this is painfully slow, so we really only want to do that in the event of a test retry. Having this property here will allow us to detect when a test is being retried and reload web driver.
